### PR TITLE
feat: support check wait status site

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -22,13 +22,15 @@ import { screenshot } from "./bot/commands/screenshot";
 import { version } from "./bot/commands/version";
 import { requireAdmin } from "./bot/middlewares/requireAdmin";
 import { requireSpecifiedChat } from "./bot/middlewares/requireSpecifiedChat";
+import { RichTextMessage } from "./bot/utils/richTextMessage";
 import { config } from "./config";
 import axiosCheck from "./methods/axios";
 import browserCheck from "./methods/browser";
 import sql from "./modules/sqlConfig";
 import { WebModel } from "./modules/sqlModel";
-import { logger } from "./modules/typedLogger";
+import { logger, time } from "./modules/typedLogger";
 import { asyncPool } from "./utils/asyncPool";
+import { WaitToRunMessageQueue } from "./utils/messageQueue";
 
 export const global = {
 	version: "7.0.0",
@@ -77,6 +79,48 @@ async function checkAll() {
 	const runWebsPercentage = (runWebsCount / allWebsCount) * 100;
 
 	logger.ok(`✓ 运行中的站点占比 ${runWebsPercentage.toFixed(2)}%`, "APP");
+	const idQueue = WaitToRunMessageQueue.getInstance();
+
+	if (process.env["PUBLIC_MODE"] !== "true" && !idQueue.isEmpty()) {
+		const message: RichTextMessage = [
+			[
+				{
+					type: "text",
+					bold: true,
+					content: "开往巡查姬提醒您：",
+				},
+			],
+		];
+		message.push([
+			{
+				type: "text",
+				content:
+					"以下的站点从 WAIT 恢复到 RUN 状态，请及时处理对应 issue",
+			},
+		]);
+		while (!idQueue.isEmpty()) {
+			const id = idQueue.dequeue();
+			if (id !== undefined) {
+				message.push([
+					{
+						type: "text",
+						content: `${id}`,
+					},
+				]);
+			}
+		}
+		message.push(
+			[{ type: "text", content: "" }],
+			[
+				{
+					type: "text",
+					content: `发送时间：${time()} CST`,
+				},
+			],
+		);
+		botManager.boardcastRichTextMessage(message);
+	}
+
 	logger.ok("△ 检测完成，Sleep.", "APP");
 }
 

--- a/src/methods/axios.ts
+++ b/src/methods/axios.ts
@@ -163,9 +163,6 @@ export default async function normalCheck(
 		// 如果未传入参数，则检查所有网站
 		webs = await WebModel.findAll({
 			where: {
-				status: {
-					[Op.notIn]: ["WAIT"],
-				},
 				lastManualCheck: {
 					[Op.or]: [
 						{ [Op.eq]: null },

--- a/src/methods/browser.ts
+++ b/src/methods/browser.ts
@@ -155,7 +155,7 @@ export default async function browserCheck(
 			const sitesToCheck = await WebModel.findAll({
 				where: {
 					status: {
-						[Op.in]: ["LOST", "ERROR", "403"],
+						[Op.in]: ["LOST", "ERROR", "403", "WAIT"],
 					},
 					lastManualCheck: {
 						[Op.or]: [

--- a/src/modules/sqlModel.ts
+++ b/src/modules/sqlModel.ts
@@ -13,9 +13,9 @@ import {
 	Model,
 } from "sequelize";
 
-import { botManager } from "../bot/botManager";
+import { WaitToRunMessageQueue } from "../utils/messageQueue";
 import sql from "./sqlConfig";
-import { Logger, time } from "./typedLogger";
+import { Logger } from "./typedLogger";
 
 class WebModel extends Model<
 	InferAttributes<WebModel>,
@@ -85,29 +85,9 @@ WebModel.init(
 							"SQL",
 						);
 						if (process.env["PUBLIC_MODE"] !== "true") {
-							botManager.boardcastRichTextMessage([
-								[
-									{
-										type: "text",
-										bold: true,
-										content: "开往巡查姬提醒您：",
-									},
-								],
-								[{ type: "text", content: "" }],
-								[
-									{
-										type: "text",
-										content: `"ID 为 ${webModel.id}" 的站点从 WAIT 恢复到 RUN 状态，请及时处理对应 issue`,
-									},
-								],
-								[{ type: "text", content: "" }],
-								[
-									{
-										type: "text",
-										content: `发送时间：${time()} CST`,
-									},
-								],
-							]);
+							WaitToRunMessageQueue.getInstance().enqueue(
+								webModel.id,
+							);
 						}
 					}
 				}

--- a/src/utils/messageQueue.ts
+++ b/src/utils/messageQueue.ts
@@ -1,0 +1,67 @@
+/*
+ * 存储从 WAIT 状态变成 RUN 状态的站点 id
+ */
+export class WaitToRunMessageQueue {
+	private static instance: WaitToRunMessageQueue; // 单例模式
+	private ids: number[] = []; // 存储 ID 的队列
+
+	private constructor() {}
+
+	/**
+	 * 获取单例实例
+	 *
+	 * @returns {WaitToRunMessageQueue} - WaitToRunMessageQueue 实例
+	 */
+	public static getInstance(): WaitToRunMessageQueue {
+		if (!WaitToRunMessageQueue.instance) {
+			WaitToRunMessageQueue.instance = new WaitToRunMessageQueue();
+		}
+		return WaitToRunMessageQueue.instance;
+	}
+
+	/**
+	 * 往队列插入 id
+	 *
+	 * @param id - 站点 id
+	 * @returns {void}
+	 */
+	public enqueue(id: number): void {
+		this.ids.push(id);
+	}
+
+	/**
+	 * 读取队列最先插入的 id 并移除
+	 *
+	 * @returns {number | undefined} - 站点 id
+	 */
+	public dequeue(): number | undefined {
+		return this.ids.shift();
+	}
+
+	/**
+	 * 获取队列长度
+	 *
+	 * @returns {number} - 队列长度
+	 */
+	public size(): number {
+		return this.ids.length;
+	}
+
+	/**
+	 * 检查队列是否为空
+	 *
+	 * @returns {boolean} - 为空则返回 true，不为空返回 false
+	 */
+	public isEmpty(): boolean {
+		return this.size() === 0;
+	}
+
+	/**
+	 * 获取队列所有 ID 的副本
+	 *
+	 * @returns {number[]}
+	 */
+	public getAllIds(): number[] {
+		return [...this.ids];
+	}
+}


### PR DESCRIPTION
由于 #35 按照组长要求改了巡查机检查范围，所以可能有一些站点要从 WAIT 恢复到 RUN 状态。
为了提高巡查效率，建议将 WAIT 状态域名也加入检查范围。

并且 hook 数据库 update 逻辑。
在 WAIT 要变成 RUN 以外的状态时阻止修改，
WAIT 变成 RUN 时直接允许数据库修改，并且使用 bot 提醒维护者去处理对应 issue。

已本地 dev-public 测试相关逻辑。