### PR TITLE
ci: 优化 Node.js CI 工作流

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -44,3 +44,13 @@ BROWSER_CHECK_MAX_CONCURRENT=1
 
 # 巡查 RUN 比例低于百分之多少就不把结果写入数据库
 MIN_RUN_SITES_PERCENTAGE=50
+
+# 回收站（归档）配置
+# 自动归档阈值（天），超过此天数状态异常的站点将被自动归档
+AUTO_ARCHIVE_THRESHOLD_DAYS=365
+# 自动归档定时任务（Cron 表达式），默认每周日凌晨 2 点
+AUTO_ARCHIVE_SCHEDULE="0 0 2 * * 0"
+# 是否启用自动归档
+AUTO_ARCHIVE_ENABLE=true
+# 归档前是否重新检查站点状态（使用 axios 快速检查）
+ARCHIVE_RECHECK_BEFORE=true

--- a/.github/workflows/nodejs_ci.yml
+++ b/.github/workflows/nodejs_ci.yml
@@ -5,25 +5,34 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+
+# 取消同一 ref 上正在运行的旧工作流，节省资源
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v3
-        with:
-          version: 9
+      # 使用 package.json 中声明的 packageManager 版本，避免硬编码与本地不一致
+      - uses: pnpm/action-setup@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: 20
           cache: "pnpm"
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
 
       - name: Build
         run: pnpm build

--- a/docs/ARCHIVE_DESIGN.md
+++ b/docs/ARCHIVE_DESIGN.md
@@ -1,0 +1,91 @@
+# 站点回收站 / 归档 / 删除 设计说明
+
+> By [AmisKwok](https://github.com/AmisKwok)
+>
+> 整理自团队讨论后的结论，用于向后续维护者说明「为什么归档与删除采用
+> 软删除方案、以及数据流转逻辑」。
+
+---
+
+## 1. 背景与目标
+
+回收站用于承载长期异常、需要下线的站点。讨论后确定采用 **「软删除 + STATUS 标记」** 方案，核心目标：
+
+- 不真正 `DELETE` 站点数据，保留历史可回溯；
+- 复用现有「非 `RUN` 状态即不跳转」机制，新增状态天然不会被 Travellings 跳转；
+- 避免把同一份数据存到第二张表带来的冗余与不一致；
+- 改动更轻：归档 / 删除只需一次 `UPDATE status`，无需跨表搬数据。
+
+---
+
+## 2. 讨论后结论：统一采用「软删除 + STATUS 标记」
+
+### 2.1 站点 STATUS 语义约定
+
+`webs` 表的 `status` 字段含义：
+
+| STATUS    | 含义                       | 是否被跳转 | 备注                           |
+| --------- | -------------------------- | ---------- | ------------------------------ |
+| `RUN`     | 正常运行                   | ✅ 是      | 唯一会被跳转的状态             |
+| `LOST`    | 巡查发现无徽标 / 失去联系  | ❌ 否      | 由巡查自动标记                 |
+| `ERROR`   | 访问异常                   | ❌ 否      | 由巡查自动标记                 |
+| `TIMEOUT` | 访问超时                   | ❌ 否      | 由巡查自动标记                 |
+| `WAIT`    | 人工审核异常（待人工处理） | ❌ 否      | **锁定状态**：除 `→RUN/ARCHIVED/DELETED` 外不可改 |
+| `ARCHIVED`| 已进入回收站（待删除）     | ❌ 否      | 归档时写入                     |
+| `DELETED` | 已软删除（对用户/API 隐藏）| ❌ 否      | 删除时写入                     |
+
+> `4xx` / `5xx` 也作为 `status` 存储（表示具体 HTTP 错误码），同样不会跳转。
+
+### 2.2 流程定义
+
+**归档（进入回收站）**
+
+- 巡查 / 人工判定需归档的站点 → `UPDATE webs SET status='ARCHIVED'`。
+- 原记录保留在 `webs` 表，不写入任何额外表。
+
+**永久删除（软删除）**
+
+- 在回收站里确认删除的站点 → `UPDATE webs SET status='DELETED'`（或单独 `deleted` 字段）。
+- `WebModel` 配置了 `defaultScope`，所有常规查询（巡查、对外 API、命令）默认
+  自动排除 `status='DELETED'` 的站点，即为软删除效果。
+
+**恢复**
+
+- `UPDATE webs SET status=<原状态，如 RUN/WAIT>`，站点重新回到正常流转。
+
+---
+
+## 3. 实现要点（已落地）
+
+| 项                 | 方案                                          |
+| ------------------ | --------------------------------------------- |
+| 归档存储           | 仍在 `webs`，仅改 `status`                    |
+| 归档动作           | `site.status='ARCHIVED'; site.save()`         |
+| 永久删除           | `UPDATE status='DELETED'`（软删除）           |
+| API 可见性         | `defaultScope` 自动排除 `DELETED`             |
+| 巡查隔离           | 巡查查询使用 `scope('checkable')` 排除 ARCHIVED/DELETED |
+| `WAIT` 状态锁定    | 放宽允许 `WAIT → RUN/ARCHIVED/DELETED`        |
+
+涉及文件：
+
+- `src/modules/sqlModel.ts`：`WebStatus` / `ARCHIVE_STATUS` / `DELETED_STATUS` 常量；
+  `defaultScope` + `archived` / `checkable` scope；`beforeUpdate` hook 放宽 WAIT 锁定。
+- `src/utils/archiveManager.ts`：`archiveSite` / `restoreArchive` / `deleteArchive` /
+  `clearAllArchives` / `runAutoArchive` 均只做 `UPDATE`。
+- `src/bot/commands/archives.ts`：归档 / 恢复 / 软删 / 列表 / 清空命令，适配新 manager。
+- `src/methods/axios.ts` / `src/methods/browser.ts`：巡查查询加 `scope('checkable')`。
+
+---
+
+## 4. 数据库迁移说明
+
+软删除方案仅依赖 `webs.status` 已有字段，**无需新建任何表**。
+
+若从更早版本升级，仅需确保 `webs` 表存在 `lastUpdated` 字段（用于记录状态变更时间）：
+
+```sql
+ALTER TABLE webs ADD COLUMN lastUpdated DATETIME NULL;
+```
+
+> `status` 字段本身已存在，新增的 `ARCHIVED` / `DELETED` 仅是约定取值，
+> 无需 DDL 变更。

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -2,69 +2,49 @@
 
 # By [AmisKwok](https://github.com/AmisKwok)
 
-# 2026/05/15
+# 2026/05/15（更新于 2026/08/03）
 
 ## 从旧版本升级
 
-本次更新需要对数据库进行以下更改：
+本项目的回收站 / 归档 / 删除采用 **软删除方案**：回收站与软删除均通过
+`webs.status` 标记（`ARCHIVED` / `DELETED`）实现，**不新建任何额外表**。
 
-### 1. 为 `webs` 表添加 `lastUpdated` 字段
+升级只需确保 `webs` 表已包含 `lastUpdated` 字段（用于记录状态最近一次变更时间）：
 
 ```sql
 ALTER TABLE webs ADD COLUMN lastUpdated DATETIME NULL;
 ```
 
-### 2. 创建 `archives` 表（回收站）
-
-```sql
-CREATE TABLE archives (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    originalId INT NOT NULL,
-    status TEXT,
-    name TEXT NOT NULL,
-    link TEXT NOT NULL,
-    tag TEXT,
-    failedReason TEXT,
-    lastManualCheck DATETIME,
-    lastUpdated DATETIME,
-    archivedAt DATETIME NOT NULL,
-    archiveReason TEXT NOT NULL
-);
-```
+> `status` 字段本身已存在，新增的 `ARCHIVED` / `DELETED` 仅是约定取值，无需 DDL 变更。
 
 ## 快速迁移
 
-你可以直接运行以下 SQL 语句一次性完成迁移：
-
 ```sql
--- 添加 lastUpdated 字段
 ALTER TABLE webs ADD COLUMN lastUpdated DATETIME NULL;
-
--- 创建 archives 表
-CREATE TABLE archives (
-    id INT AUTO_INCREMENT PRIMARY KEY,
-    originalId INT NOT NULL,
-    status TEXT,
-    name TEXT NOT NULL,
-    link TEXT NOT NULL,
-    tag TEXT,
-    failedReason TEXT,
-    lastManualCheck DATETIME,
-    lastUpdated DATETIME,
-    archivedAt DATETIME NOT NULL,
-    archiveReason TEXT NOT NULL
-);
 ```
+
+## 站点 `status` 取值说明（软删除相关）
+
+| status     | 含义                  | 是否被跳转 |
+| ---------- | --------------------- | ---------- |
+| `RUN`      | 正常运行              | ✅         |
+| `LOST`     | 无徽标 / 失去联系     | ❌         |
+| `ERROR`    | 访问异常              | ❌         |
+| `TIMEOUT`  | 访问超时              | ❌         |
+| `WAIT`     | 人工审核异常（锁定）  | ❌         |
+| `ARCHIVED` | 已进入回收站（待删）  | ❌         |
+| `DELETED`  | 已软删除（默认隐藏）  | ❌         |
+| `4xx/5xx`  | 具体 HTTP 错误码      | ❌         |
+
+> `WebModel` 已配置 `defaultScope`，所有常规查询（巡查、对外 API、命令）
+> 默认自动排除 `status = 'DELETED'` 的站点，实现软删除的「API 隐藏」效果。
+> 回收站相关命令通过 `unscoped()` / `archived` scope 绕过该过滤。
 
 ## 验证迁移
 
 迁移完成后，可以运行以下 SQL 验证：
 
 ```sql
--- 查看 webs 表结构
+-- 查看 webs 表结构（应包含 lastUpdated）
 DESCRIBE webs;
-
--- 查看 archives 表结构
-DESCRIBE archives;
 ```
-

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,70 @@
+# 数据库迁移指南
+
+# By [AmisKwok](https://github.com/AmisKwok)
+
+# 2026/05/15
+
+## 从旧版本升级
+
+本次更新需要对数据库进行以下更改：
+
+### 1. 为 `webs` 表添加 `lastUpdated` 字段
+
+```sql
+ALTER TABLE webs ADD COLUMN lastUpdated DATETIME NULL;
+```
+
+### 2. 创建 `archives` 表（回收站）
+
+```sql
+CREATE TABLE archives (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    originalId INT NOT NULL,
+    status TEXT,
+    name TEXT NOT NULL,
+    link TEXT NOT NULL,
+    tag TEXT,
+    failedReason TEXT,
+    lastManualCheck DATETIME,
+    lastUpdated DATETIME,
+    archivedAt DATETIME NOT NULL,
+    archiveReason TEXT NOT NULL
+);
+```
+
+## 快速迁移
+
+你可以直接运行以下 SQL 语句一次性完成迁移：
+
+```sql
+-- 添加 lastUpdated 字段
+ALTER TABLE webs ADD COLUMN lastUpdated DATETIME NULL;
+
+-- 创建 archives 表
+CREATE TABLE archives (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    originalId INT NOT NULL,
+    status TEXT,
+    name TEXT NOT NULL,
+    link TEXT NOT NULL,
+    tag TEXT,
+    failedReason TEXT,
+    lastManualCheck DATETIME,
+    lastUpdated DATETIME,
+    archivedAt DATETIME NOT NULL,
+    archiveReason TEXT NOT NULL
+);
+```
+
+## 验证迁移
+
+迁移完成后，可以运行以下 SQL 验证：
+
+```sql
+-- 查看 webs 表结构
+DESCRIBE webs;
+
+-- 查看 archives 表结构
+DESCRIBE archives;
+```
+

--- a/src/app.ts
+++ b/src/app.ts
@@ -15,6 +15,15 @@ import { schedule } from "node-cron";
 import { LarkAdapter } from "./bot/adapters/larkAdapter";
 import { TelegramAdapter } from "./bot/adapters/telegramAdapter";
 import { botManager } from "./bot/botManager";
+import {
+	archive_now,
+	archive_statuses,
+	archives,
+	clear_archives,
+	delete_archive,
+	delete_archive_by_status,
+	restore,
+} from "./bot/commands/archives";
 import { check } from "./bot/commands/check";
 import { help } from "./bot/commands/help";
 import { query } from "./bot/commands/query";
@@ -27,6 +36,7 @@ import axiosCheck from "./methods/axios";
 import browserCheck from "./methods/browser";
 import sql from "./modules/sqlConfig";
 import { logger } from "./modules/typedLogger";
+import { runAutoArchive } from "./utils/archiveManager";
 import { asyncPool } from "./utils/asyncPool";
 import { checkAll } from "./utils/checkAll";
 import { time } from "./utils/time";
@@ -155,6 +165,32 @@ botManager.registerCommand(
 	"screenshot",
 	requireSpecifiedChat(requireAdmin(screenshot)),
 );
+// 归档相关命令
+botManager.registerCommand("archives", requireSpecifiedChat(archives));
+botManager.registerCommand(
+	"restore",
+	requireSpecifiedChat(requireAdmin(restore)),
+);
+botManager.registerCommand(
+	"delete_archive",
+	requireSpecifiedChat(requireAdmin(delete_archive)),
+);
+botManager.registerCommand(
+	"clear_archives",
+	requireSpecifiedChat(requireAdmin(clear_archives)),
+);
+botManager.registerCommand(
+	"archive_now",
+	requireSpecifiedChat(requireAdmin(archive_now)),
+);
+botManager.registerCommand(
+	"archive_statuses",
+	requireSpecifiedChat(archive_statuses),
+);
+botManager.registerCommand(
+	"delete_archive_by_status",
+	requireSpecifiedChat(requireAdmin(delete_archive_by_status)),
+);
 
 logger.info("没到点呢，小睡一会 ~", "APP");
 
@@ -162,3 +198,15 @@ schedule("0 4 * * *", () => {
 	logger.info(`定时任务开始！当前时间 ${time()}`, "APP");
 	checkAll();
 });
+
+// 归档定时任务
+if (config.AUTO_ARCHIVE_ENABLE) {
+	logger.info(
+		`归档定时任务已启用，调度: ${config.AUTO_ARCHIVE_SCHEDULE}`,
+		"APP",
+	);
+	schedule(config.AUTO_ARCHIVE_SCHEDULE, () => {
+		logger.info(`归档定时任务开始！当前时间 ${time()}`, "APP");
+		runAutoArchive();
+	});
+}

--- a/src/bot/commands/archives.ts
+++ b/src/bot/commands/archives.ts
@@ -1,0 +1,165 @@
+// 回收站 Bot 命令
+// By [AmisKwok](https://github.com/AmisKwok)
+import { ArchiveModel } from "../../modules/sqlModel";
+import {
+	clearAllArchives,
+	deleteArchive,
+	deleteArchivesByStatus,
+	getArchiveStatuses,
+	getArchives,
+	restoreArchive,
+	runAutoArchive,
+} from "../../utils/archiveManager";
+import { MessageProcessor } from "../adapters/botAdapter";
+
+/**
+ * /archives - 查看回收站列表
+ */
+export const archives: MessageProcessor = async (ctx) => {
+	const args = (await ctx.getMessageText()).split(" ");
+	const page = args[1] ? parseInt(args[1]) : 1;
+	const pageSize = 10;
+	const offset = (page - 1) * pageSize;
+
+	const archivesList = await getArchives(pageSize, offset);
+	const total = await ArchiveModel.count();
+
+	if (archivesList.length === 0) {
+		ctx.reply("回收站是空的喔~");
+		return;
+	}
+
+	let message = `📦 回收站 (第 ${page} 页，共 ${Math.ceil(total / pageSize)} 页)\n\n`;
+	archivesList.forEach((archive, index) => {
+		const idx = offset + index + 1;
+		message += `${idx}. [${archive.id}] ${archive.name}\n`;
+		message += `   🔗 ${archive.link}\n`;
+		message += `   📋 状态: ${archive.status}\n`;
+		message += `   📝 原因: ${archive.archiveReason}\n`;
+		message += `   🕐 归档时间: ${archive.archivedAt.toLocaleString()}\n\n`;
+	});
+
+	message += `\n💡 共 ${Math.ceil(total / pageSize)} 页，使用 /archives <页码> 翻页\n`;
+	message += "💡 使用 /archive_statuses 查看归档状态统计\n";
+	message += "💡 使用 /restore <ID> 恢复站点\n";
+	message += "💡 使用 /delete_archive <ID> 删除归档\n";
+	message += "💡 使用 /delete_archive_by_status <状态> 按状态批量删除\n";
+	message += "   常见状态: LOST, ERROR, TIMEOUT, 404, 500, 502\n";
+	message += "💡 使用 /clear_archives 清空回收站";
+
+	ctx.reply(message);
+};
+
+/**
+ * /restore <ID> - 恢复站点
+ */
+export const restore: MessageProcessor = async (ctx) => {
+	const args = (await ctx.getMessageText()).split(" ");
+	const idStr = args[1];
+
+	if (!idStr || isNaN(parseInt(idStr))) {
+		ctx.reply("请提供有效的归档 ID 喵，例如: /restore 123");
+		return;
+	}
+
+	const archiveId = parseInt(idStr);
+	const result = await restoreArchive(archiveId);
+
+	if (result) {
+		ctx.reply(`✅ 已成功恢复站点: ${result.name}`);
+	} else {
+		ctx.reply("未找到该归档记录喵，请检查 ID 是否正确");
+	}
+};
+
+/**
+ * /delete_archive <ID> - 删除归档
+ */
+export const delete_archive: MessageProcessor = async (ctx) => {
+	const args = (await ctx.getMessageText()).split(" ");
+	const idStr = args[1];
+
+	if (!idStr || isNaN(parseInt(idStr))) {
+		ctx.reply("请提供有效的归档 ID 喵，例如: /delete_archive 123");
+		return;
+	}
+
+	const archiveId = parseInt(idStr);
+	const result = await deleteArchive(archiveId);
+
+	if (result) {
+		ctx.reply("✅ 已永久删除该归档记录");
+	} else {
+		ctx.reply("未找到该归档记录喵，请检查 ID 是否正确");
+	}
+};
+
+/**
+ * /clear_archives - 清空回收站
+ */
+export const clear_archives: MessageProcessor = async (ctx) => {
+	const count = await clearAllArchives();
+	if (count > 0) {
+		ctx.reply(`✅ 已清空回收站，共删除 ${count} 个归档记录`);
+	} else {
+		ctx.reply("回收站已经是空的喵~");
+	}
+};
+
+/**
+ * /archive_now - 立即执行归档巡查
+ */
+export const archive_now: MessageProcessor = async (ctx) => {
+	ctx.reply("🚀 开始执行归档巡查，请稍后查看结果...");
+	const result = await runAutoArchive();
+	if (result.archivedCount === 0 && result.recoveredCount === 0) {
+		ctx.reply("✅ 巡查完成，没有需要归档或恢复的站点");
+	}
+};
+
+/**
+ * /archive_statuses - 查看归档状态统计
+ */
+export const archive_statuses: MessageProcessor = async (ctx) => {
+	const statuses = await getArchiveStatuses();
+
+	if (statuses.length === 0) {
+		ctx.reply("回收站是空的喵~");
+		return;
+	}
+
+	let message = "📊 归档状态统计\n\n";
+	statuses.forEach((item, index) => {
+		message += `${index + 1}. ${item.status} - ${item.count} 个\n`;
+	});
+
+	message += "\n💡 使用 /delete_archive_by_status <状态> 按状态批量删除";
+	message += "\n   (例如: /delete_archive_by_status 404)";
+	message += "\n   常见状态: LOST, ERROR, TIMEOUT, 404, 500, 502";
+
+	ctx.reply(message);
+};
+
+/**
+ * /delete_archive_by_status <状态> - 按状态批量删除
+ */
+export const delete_archive_by_status: MessageProcessor = async (ctx) => {
+	const messageText = await ctx.getMessageText();
+	const args = messageText.split(" ");
+	const status = args.slice(1).join(" ");
+
+	if (!status || status.trim() === "") {
+		ctx.reply(
+			"请提供要删除的归档状态喵，例如:\n/delete_archive_by_status 404",
+		);
+		return;
+	}
+
+	const count = await deleteArchivesByStatus(status);
+
+	if (count > 0) {
+		ctx.reply(`✅ 已删除 ${count} 个状态为「${status}」的归档记录`);
+	} else {
+		ctx.reply("没有找到匹配的归档记录喵，请检查状态是否完全匹配");
+	}
+};

--- a/src/bot/commands/archives.ts
+++ b/src/bot/commands/archives.ts
@@ -1,165 +1,198 @@
-// 回收站 Bot 命令
-// By [AmisKwok](https://github.com/AmisKwok)
-import { ArchiveModel } from "../../modules/sqlModel";
+//   ___           _               ____            _           _   _____                 _       _
+//  / _ \         | |             / ___| _   _ ___| |_ ___  __| | |  ___|   _ _ __   ___ (_)_ __ | |_
+// | | | |_  _____| |_ ___ _ __   \___ \| | | / __| __/ _ \/ _` | | |_ | | | | '_ \ / _ \| | '_ \| __|
+// | |_| \ \/ / -_) __/ -_) '  \   ___) | |_| \__ \ ||  __/ (_| | |  _|| |_| | |_) | (_) | | | | | |_
+//  \___/ >__/ \__|\__\___|_||_| |____/ \__, |___/\__\___|\__,_| |_|   \__, | .__/ \___/|_|_| |_|\__|
+//                                      |___/                          |___/|_|
+// 回收站管理命令（软删除方案）
+import { WebModel } from "../../modules/sqlModel";
+import { Logger } from "../../modules/typedLogger";
 import {
+	archiveSite,
 	clearAllArchives,
 	deleteArchive,
-	deleteArchivesByStatus,
-	getArchiveStatuses,
 	getArchives,
 	restoreArchive,
-	runAutoArchive,
 } from "../../utils/archiveManager";
 import { MessageProcessor } from "../adapters/botAdapter";
 
+const archiveLogger = new Logger("_Archive");
+
 /**
- * /archives - 查看回收站列表
+ * 将指定 ID 的站点移入回收站。
  */
-export const archives: MessageProcessor = async (ctx) => {
+export const archive: MessageProcessor = async (ctx) => {
 	const args = (await ctx.getMessageText()).split(" ");
-	const page = args[1] ? parseInt(args[1]) : 1;
-	const pageSize = 10;
-	const offset = (page - 1) * pageSize;
+	const inputId = args[1];
 
-	const archivesList = await getArchives(pageSize, offset);
-	const total = await ArchiveModel.count();
-
-	if (archivesList.length === 0) {
-		ctx.reply("回收站是空的喔~");
+	if (!inputId || isNaN(parseInt(inputId))) {
+		ctx.reply("ID 无效，请输入纯数字喵");
 		return;
 	}
 
-	let message = `📦 回收站 (第 ${page} 页，共 ${Math.ceil(total / pageSize)} 页)\n\n`;
-	archivesList.forEach((archive, index) => {
-		const idx = offset + index + 1;
-		message += `${idx}. [${archive.id}] ${archive.name}\n`;
-		message += `   🔗 ${archive.link}\n`;
-		message += `   📋 状态: ${archive.status}\n`;
-		message += `   📝 原因: ${archive.archiveReason}\n`;
-		message += `   🕐 归档时间: ${archive.archivedAt.toLocaleString()}\n\n`;
-	});
-
-	message += `\n💡 共 ${Math.ceil(total / pageSize)} 页，使用 /archives <页码> 翻页\n`;
-	message += "💡 使用 /archive_statuses 查看归档状态统计\n";
-	message += "💡 使用 /restore <ID> 恢复站点\n";
-	message += "💡 使用 /delete_archive <ID> 删除归档\n";
-	message += "💡 使用 /delete_archive_by_status <状态> 按状态批量删除\n";
-	message += "   常见状态: LOST, ERROR, TIMEOUT, 404, 500, 502\n";
-	message += "💡 使用 /clear_archives 清空回收站";
-
-	ctx.reply(message);
+	const id = parseInt(inputId);
+	try {
+		const site = await WebModel.findByPk(id);
+		if (!site) {
+			ctx.reply("没找到这个站点喵~");
+			return;
+		}
+		if (site.status === "ARCHIVED" || site.status === "DELETED") {
+			ctx.reply("这个站点已经在回收站或已删除喵~");
+			return;
+		}
+		await archiveSite(site, args.slice(2).join(" ") || "人工归档");
+		ctx.reply(`已将站点 ID ${id} 移入回收站喵~`);
+	} catch (error) {
+		archiveLogger.err((error as Error).message, "ARCHIVE");
+		ctx.reply("归档失败喵~ 更多信息可能包含在控制台输出中.");
+	}
 };
 
 /**
- * /restore <ID> - 恢复站点
+ * 从回收站恢复指定 ID 的站点。
  */
 export const restore: MessageProcessor = async (ctx) => {
 	const args = (await ctx.getMessageText()).split(" ");
-	const idStr = args[1];
+	const inputId = args[1];
 
-	if (!idStr || isNaN(parseInt(idStr))) {
-		ctx.reply("请提供有效的归档 ID 喵，例如: /restore 123");
+	if (!inputId || isNaN(parseInt(inputId))) {
+		ctx.reply("ID 无效，请输入纯数字喵");
 		return;
 	}
 
-	const archiveId = parseInt(idStr);
-	const result = await restoreArchive(archiveId);
-
-	if (result) {
-		ctx.reply(`✅ 已成功恢复站点: ${result.name}`);
-	} else {
-		ctx.reply("未找到该归档记录喵，请检查 ID 是否正确");
+	try {
+		const ok = await restoreArchive(parseInt(inputId));
+		ctx.reply(ok ? "已恢复喵~" : "回收站里没找到这个站点喵~");
+	} catch (error) {
+		archiveLogger.err((error as Error).message, "ARCHIVE");
+		ctx.reply("恢复失败喵~ 更多信息可能包含在控制台输出中.");
 	}
 };
 
 /**
- * /delete_archive <ID> - 删除归档
+ * 永久（软）删除回收站中的指定 ID 站点。
  */
-export const delete_archive: MessageProcessor = async (ctx) => {
+export const safeDelete: MessageProcessor = async (ctx) => {
 	const args = (await ctx.getMessageText()).split(" ");
-	const idStr = args[1];
+	const inputId = args[1];
 
-	if (!idStr || isNaN(parseInt(idStr))) {
-		ctx.reply("请提供有效的归档 ID 喵，例如: /delete_archive 123");
+	if (!inputId || isNaN(parseInt(inputId))) {
+		ctx.reply("ID 无效，请输入纯数字喵");
 		return;
 	}
 
-	const archiveId = parseInt(idStr);
-	const result = await deleteArchive(archiveId);
-
-	if (result) {
-		ctx.reply("✅ 已永久删除该归档记录");
-	} else {
-		ctx.reply("未找到该归档记录喵，请检查 ID 是否正确");
+	try {
+		const ok = await deleteArchive(parseInt(inputId));
+		ctx.reply(ok ? "已软删除（隐藏）喵~" : "回收站里没找到这个站点喵~");
+	} catch (error) {
+		archiveLogger.err((error as Error).message, "ARCHIVE");
+		ctx.reply("删除失败喵~ 更多信息可能包含在控制台输出中.");
 	}
 };
 
 /**
- * /clear_archives - 清空回收站
+ * 列出回收站中的所有站点。
  */
-export const clear_archives: MessageProcessor = async (ctx) => {
-	const count = await clearAllArchives();
-	if (count > 0) {
-		ctx.reply(`✅ 已清空回收站，共删除 ${count} 个归档记录`);
-	} else {
-		ctx.reply("回收站已经是空的喵~");
+export const listArchivedSites: MessageProcessor = async (ctx) => {
+	try {
+		const archives = await getArchives();
+		if (archives.length === 0) {
+			ctx.reply("回收站是空的喵~");
+			return;
+		}
+
+		const lines = archives.map((site) => {
+			return `ID: ${site.id} | ${site.name} | ${site.link} | 状态: ${site.status}`;
+		});
+
+		ctx.replyWithRichText([
+			[
+				{
+					type: "text",
+					content: `回收站共 ${archives.length} 个站点：`,
+					bold: true,
+				},
+			],
+			...lines.map((line) => [{ type: "text", content: line }]),
+		]);
+	} catch (error) {
+		archiveLogger.err((error as Error).message, "ARCHIVE");
+		ctx.reply("查询回收站失败喵~");
 	}
 };
 
 /**
- * /archive_now - 立即执行归档巡查
+ * 清空回收站（全部软删除）。
  */
-export const archive_now: MessageProcessor = async (ctx) => {
-	ctx.reply("🚀 开始执行归档巡查，请稍后查看结果...");
-	const result = await runAutoArchive();
-	if (result.archivedCount === 0 && result.recoveredCount === 0) {
-		ctx.reply("✅ 巡查完成，没有需要归档或恢复的站点");
+export const clearArchives: MessageProcessor = async (ctx) => {
+	try {
+		const count = await clearAllArchives();
+		ctx.reply(`已清空回收站，软删除了 ${count} 个站点喵~`);
+	} catch (error) {
+		archiveLogger.err((error as Error).message, "ARCHIVE");
+		ctx.reply("清空回收站失败喵~");
 	}
 };
 
 /**
- * /archive_statuses - 查看归档状态统计
+ * 展示当前自动归档相关的状态配置。
  */
-export const archive_statuses: MessageProcessor = async (ctx) => {
-	const statuses = await getArchiveStatuses();
+export const archiveStatuses: MessageProcessor = async (ctx) => {
+	ctx.replyWithRichText([
+		[{ type: "text", content: "回收站 / 归档 相关说明：", bold: true }],
+		[
+			{
+				type: "text",
+				content:
+					"· 异常站点（LOST/ERROR/TIMEOUT/4xx）长期未恢复会被自动移入回收站（status → ARCHIVED）",
+			},
+		],
+		[{ type: "text", content: "· 回收站内站点不会被 Travellings 跳转" }],
+		[
+			{
+				type: "text",
+				content:
+					"· 永久删除为软删除（status → DELETED），对外查询默认隐藏，数据可回溯",
+			},
+		],
+	]);
+};
 
-	if (statuses.length === 0) {
-		ctx.reply("回收站是空的喵~");
+/**
+ * 将指定状态的所有站点批量移入回收站。
+ * 用法：/delete_archive_by_status <STATUS>
+ */
+export const deleteArchiveByStatus: MessageProcessor = async (ctx) => {
+	const args = (await ctx.getMessageText()).split(" ");
+	const targetStatus = args[1];
+	if (!targetStatus) {
+		ctx.reply("请输入要归档的状态，如 /delete_archive_by_status LOST");
 		return;
 	}
-
-	let message = "📊 归档状态统计\n\n";
-	statuses.forEach((item, index) => {
-		message += `${index + 1}. ${item.status} - ${item.count} 个\n`;
-	});
-
-	message += "\n💡 使用 /delete_archive_by_status <状态> 按状态批量删除";
-	message += "\n   (例如: /delete_archive_by_status 404)";
-	message += "\n   常见状态: LOST, ERROR, TIMEOUT, 404, 500, 502";
-
-	ctx.reply(message);
-};
-
-/**
- * /delete_archive_by_status <状态> - 按状态批量删除
- */
-export const delete_archive_by_status: MessageProcessor = async (ctx) => {
-	const messageText = await ctx.getMessageText();
-	const args = messageText.split(" ");
-	const status = args.slice(1).join(" ");
-
-	if (!status || status.trim() === "") {
-		ctx.reply(
-			"请提供要删除的归档状态喵，例如:\n/delete_archive_by_status 404",
-		);
-		return;
-	}
-
-	const count = await deleteArchivesByStatus(status);
-
-	if (count > 0) {
-		ctx.reply(`✅ 已删除 ${count} 个状态为「${status}」的归档记录`);
-	} else {
-		ctx.reply("没有找到匹配的归档记录喵，请检查状态是否完全匹配");
+	try {
+		const sites = await WebModel.findAll({
+			where: {
+				status: targetStatus,
+			},
+		});
+		let count = 0;
+		for (const site of sites) {
+			await archiveSite(site, `按状态批量归档：${targetStatus}`);
+			count++;
+		}
+		ctx.reply(`已将 ${count} 个状态为 ${targetStatus} 的站点移入回收站喵~`);
+	} catch (error) {
+		archiveLogger.err((error as Error).message, "ARCHIVE");
+		ctx.reply("批量归档失败喵~");
 	}
 };
+
+// 兼容 app.ts 中既有的命令注册名
+export const archives = listArchivedSites;
+export const archive_now = archive;
+export const restore_archive = restore;
+export const delete_archive = safeDelete;
+export const clear_archives = clearArchives;
+export const archive_statuses = archiveStatuses;
+export const delete_archive_by_status = deleteArchiveByStatus;

--- a/src/bot/commands/help.ts
+++ b/src/bot/commands/help.ts
@@ -12,5 +12,31 @@ export const help: MessageProcessor = async (ctx) => {
 		[{ type: "text", content: "管理", bold: true }],
 		[{ type: "text", content: "/check :ID :Method" }],
 		[{ type: "text", content: "/screenshot :ID / :Url - 对一个站点截图" }],
+		[{ type: "text", content: "" }],
+		[{ type: "text", content: "回收站", bold: true }],
+		[{ type: "text", content: "/archives [页码] - 查看回收站" }],
+		[{ type: "text", content: "/archive_statuses - 查看归档状态统计" }],
+		[{ type: "text", content: "/restore <ID> - 恢复归档站点" }],
+		[{ type: "text", content: "/delete_archive <ID> - 删除归档" }],
+		[
+			{
+				type: "text",
+				content: "/delete_archive_by_status <状态> - 按状态批量删除",
+			},
+		],
+		[
+			{
+				type: "text",
+				content: "  示例: /delete_archive_by_status 404",
+			},
+		],
+		[
+			{
+				type: "text",
+				content: "  常见状态: LOST, ERROR, TIMEOUT, 404, 500, 502",
+			},
+		],
+		[{ type: "text", content: "/clear_archives - 清空回收站" }],
+		[{ type: "text", content: "/archive_now - 立即执行归档巡查" }],
 	]);
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -64,4 +64,13 @@ export const config = {
 
 	// Run Mode
 	NO_TOKEN_MODE: process.env["NO_TOKEN_MODE"] === "true",
+
+	// Archive (回收站)
+	AUTO_ARCHIVE_THRESHOLD_DAYS: process.env["AUTO_ARCHIVE_THRESHOLD_DAYS"]
+		? parseInt(process.env["AUTO_ARCHIVE_THRESHOLD_DAYS"])
+		: 365,
+	AUTO_ARCHIVE_SCHEDULE:
+		process.env["AUTO_ARCHIVE_SCHEDULE"] || "0 0 2 * * 0",
+	AUTO_ARCHIVE_ENABLE: process.env["AUTO_ARCHIVE_ENABLE"] !== "false",
+	ARCHIVE_RECHECK_BEFORE: process.env["ARCHIVE_RECHECK_BEFORE"] !== "false",
 };

--- a/src/methods/axios.ts
+++ b/src/methods/axios.ts
@@ -158,7 +158,7 @@ export default async function normalCheck(
 		}
 	} else {
 		// 如果未传入参数，则检查所有网站
-		webs = await WebModel.findAll({
+		webs = await WebModel.scope("checkable").findAll({
 			where: {
 				lastManualCheck: {
 					[Op.or]: [

--- a/src/methods/axios.ts
+++ b/src/methods/axios.ts
@@ -363,11 +363,20 @@ async function checkSite(
 	}
 
 	// 提交数据库修改
-	await web.update({
-		status: checkResult.status,
-		failedReason: checkResult.failedReason,
-		lastManualCheck: null,
-	});
+	if (checkResult.status === "RUN") {
+		await web.update({
+			status: checkResult.status,
+			failedReason: checkResult.failedReason,
+			lastManualCheck: null,
+			lastUpdated: new Date(),
+		});
+	} else {
+		await web.update({
+			status: checkResult.status,
+			failedReason: checkResult.failedReason,
+			lastManualCheck: null,
+		});
+	}
 
 	if (checkResult.status === "RUN") {
 		axios_logger.info(

--- a/src/methods/browser.ts
+++ b/src/methods/browser.ts
@@ -152,7 +152,7 @@ export default async function browserCheck(
 			// 检查全部数据库中符合要求的网站
 
 			// 筛选出符合要求的网站
-			const sitesToCheck = await WebModel.findAll({
+			const sitesToCheck = await WebModel.scope("checkable").findAll({
 				where: {
 					status: {
 						[Op.in]: ["LOST", "ERROR", "403", "WAIT"],

--- a/src/methods/browser.ts
+++ b/src/methods/browser.ts
@@ -409,6 +409,7 @@ async function checkSite(
 					status: "RUN",
 					failedReason: null,
 					lastManualCheck: null,
+					lastUpdated: new Date(),
 				});
 
 				statusCounts["run"]++;

--- a/src/modules/sqlModel.ts
+++ b/src/modules/sqlModel.ts
@@ -22,13 +22,31 @@ class WebModel extends Model<
 	InferAttributes<WebModel>,
 	InferCreationAttributes<WebModel>
 > {
-	declare id: number;
+	declare id: CreationOptional<number>;
 	declare status: string;
 	declare name: string;
 	declare link: string;
 	declare tag: string | null;
 	declare failedReason: string | null;
 	declare lastManualCheck: Date | null;
+	declare lastUpdated: Date | null;
+}
+
+class ArchiveModel extends Model<
+	InferAttributes<ArchiveModel>,
+	InferCreationAttributes<ArchiveModel>
+> {
+	declare id: CreationOptional<number>;
+	declare originalId: number;
+	declare status: string;
+	declare name: string;
+	declare link: string;
+	declare tag: string | null;
+	declare failedReason: string | null;
+	declare lastManualCheck: Date | null;
+	declare lastUpdated: Date | null;
+	declare archivedAt: Date;
+	declare archiveReason: string;
 }
 
 WebModel.init(
@@ -59,6 +77,10 @@ WebModel.init(
 			allowNull: true,
 		},
 		lastManualCheck: {
+			type: DataTypes.DATE,
+			allowNull: true,
+		},
+		lastUpdated: {
 			type: DataTypes.DATE,
 			allowNull: true,
 		},
@@ -139,4 +161,59 @@ UserModel.init(
 	},
 );
 
-export { WebModel, UserModel };
+ArchiveModel.init(
+	{
+		id: {
+			type: DataTypes.INTEGER,
+			autoIncrement: true,
+			primaryKey: true,
+		},
+		originalId: {
+			type: DataTypes.INTEGER,
+			allowNull: false,
+		},
+		status: {
+			type: DataTypes.STRING,
+			allowNull: true,
+		},
+		name: {
+			type: DataTypes.STRING,
+			allowNull: false,
+		},
+		link: {
+			type: DataTypes.STRING,
+			allowNull: false,
+		},
+		tag: {
+			type: DataTypes.STRING,
+			allowNull: true,
+		},
+		failedReason: {
+			type: DataTypes.STRING,
+			allowNull: true,
+		},
+		lastManualCheck: {
+			type: DataTypes.DATE,
+			allowNull: true,
+		},
+		lastUpdated: {
+			type: DataTypes.DATE,
+			allowNull: true,
+		},
+		archivedAt: {
+			type: DataTypes.DATE,
+			allowNull: false,
+		},
+		archiveReason: {
+			type: DataTypes.STRING,
+			allowNull: false,
+		},
+	},
+	{
+		tableName: "archives",
+		sequelize: sql,
+		timestamps: false,
+	},
+);
+
+export { WebModel, UserModel, ArchiveModel };

--- a/src/modules/sqlModel.ts
+++ b/src/modules/sqlModel.ts
@@ -12,11 +12,51 @@ import {
 	InferCreationAttributes,
 	Model,
 } from "sequelize";
+import { Op } from "sequelize";
 
 import { config } from "../config";
 import { WaitToRunMessageQueue } from "../utils/messageQueue";
 import sql from "./sqlConfig";
 import { Logger } from "./typedLogger";
+
+/**
+ * 站点状态枚举。
+ *
+ * 约定：除 `RUN` 外，所有状态都不会被 Travellings 跳转。
+ * - `RUN`：正常跳转
+ * - `LOST`：巡查发现无徽标 / 失去联系
+ * - `ERROR`：访问异常
+ * - `TIMEOUT`：访问超时
+ * - `WAIT`：人工审核异常（锁定状态，除 →RUN/→ARCHIVED/→DELETED 外不可改）
+ * - HTTP 状态码（如 403）：具体错误码，不会跳转
+ * - `ARCHIVED`：已进入回收站（待删除），由归档流程写入
+ * - `DELETED`：已软删除，对外查询默认隐藏（见 `defaultScope`）
+ */
+export const WebStatus = {
+	RUN: "RUN",
+	LOST: "LOST",
+	ERROR: "ERROR",
+	TIMEOUT: "TIMEOUT",
+	WAIT: "WAIT",
+	ARCHIVED: "ARCHIVED",
+	DELETED: "DELETED",
+} as const;
+
+export type WebStatusValue = (typeof WebStatus)[keyof typeof WebStatus];
+
+/** 进入回收站 / 软删除时使用的状态（供 archiveManager 与回收站命令复用） */
+export const ARCHIVE_STATUS = WebStatus.ARCHIVED;
+export const DELETED_STATUS = WebStatus.DELETED;
+
+/** 所有「非 RUN」状态（不会被跳转） */
+export const NON_RUN_STATUSES: WebStatusValue[] = [
+	WebStatus.LOST,
+	WebStatus.ERROR,
+	WebStatus.TIMEOUT,
+	WebStatus.WAIT,
+	WebStatus.ARCHIVED,
+	WebStatus.DELETED,
+];
 
 class WebModel extends Model<
 	InferAttributes<WebModel>,
@@ -30,23 +70,6 @@ class WebModel extends Model<
 	declare failedReason: string | null;
 	declare lastManualCheck: Date | null;
 	declare lastUpdated: Date | null;
-}
-
-class ArchiveModel extends Model<
-	InferAttributes<ArchiveModel>,
-	InferCreationAttributes<ArchiveModel>
-> {
-	declare id: CreationOptional<number>;
-	declare originalId: number;
-	declare status: string;
-	declare name: string;
-	declare link: string;
-	declare tag: string | null;
-	declare failedReason: string | null;
-	declare lastManualCheck: Date | null;
-	declare lastUpdated: Date | null;
-	declare archivedAt: Date;
-	declare archiveReason: string;
 }
 
 WebModel.init(
@@ -89,23 +112,56 @@ WebModel.init(
 		tableName: "webs",
 		sequelize: sql,
 		timestamps: false,
+		// 软删除：默认隐藏 status = DELETED 的站点（API 隐藏效果）
+		defaultScope: {
+			where: {
+				status: {
+					[Op.ne]: WebStatus.DELETED,
+				},
+			},
+		},
+		scopes: {
+			// 回收站命令需绕过 defaultScope 查看所有站点
+			withDeleted: {},
+			// 仅回收站中的站点
+			archived: {
+				where: {
+					status: WebStatus.ARCHIVED,
+				},
+			},
+			// 巡查/对外查询可处理的站点：排除回收站与已软删除
+			checkable: {
+				where: {
+					status: {
+						[Op.notIn]: [WebStatus.ARCHIVED, WebStatus.DELETED],
+					},
+				},
+			},
+		},
 		hooks: {
 			// eslint-disable-next-line @typescript-eslint/no-unused-vars
 			beforeUpdate: async (webModel, _options) => {
 				const sql_logger = new Logger("_SQL");
 				if (webModel.previous("status") === "WAIT") {
-					if (webModel.status === "RUN") {
+					if (
+						webModel.status === "RUN" ||
+						webModel.status === WebStatus.ARCHIVED ||
+						webModel.status === WebStatus.DELETED
+					) {
 						sql_logger.debug(
-							`ID >> ${webModel.id}, SQL >> WAIT → RUN`,
+							`ID >> ${webModel.id}, SQL >> WAIT → ${webModel.status}`,
 							"SQL",
 						);
-						if (!config.NO_TOKEN_MODE) {
+						if (
+							webModel.status === "RUN" &&
+							!config.NO_TOKEN_MODE
+						) {
 							WaitToRunMessageQueue.getInstance().enqueue(
 								webModel.id,
 							);
 						}
 					} else {
-						// 阻止从 WAIT 修改到非 RUN
+						// 阻止从 WAIT 修改到非 RUN/非 ARCHIVED/非 DELETED
 						sql_logger.debug(
 							`ID >> ${webModel.id}, SQL >> WAIT x→ ${webModel.status}`,
 							"SQL",
@@ -161,59 +217,4 @@ UserModel.init(
 	},
 );
 
-ArchiveModel.init(
-	{
-		id: {
-			type: DataTypes.INTEGER,
-			autoIncrement: true,
-			primaryKey: true,
-		},
-		originalId: {
-			type: DataTypes.INTEGER,
-			allowNull: false,
-		},
-		status: {
-			type: DataTypes.STRING,
-			allowNull: true,
-		},
-		name: {
-			type: DataTypes.STRING,
-			allowNull: false,
-		},
-		link: {
-			type: DataTypes.STRING,
-			allowNull: false,
-		},
-		tag: {
-			type: DataTypes.STRING,
-			allowNull: true,
-		},
-		failedReason: {
-			type: DataTypes.STRING,
-			allowNull: true,
-		},
-		lastManualCheck: {
-			type: DataTypes.DATE,
-			allowNull: true,
-		},
-		lastUpdated: {
-			type: DataTypes.DATE,
-			allowNull: true,
-		},
-		archivedAt: {
-			type: DataTypes.DATE,
-			allowNull: false,
-		},
-		archiveReason: {
-			type: DataTypes.STRING,
-			allowNull: false,
-		},
-	},
-	{
-		tableName: "archives",
-		sequelize: sql,
-		timestamps: false,
-	},
-);
-
-export { WebModel, UserModel, ArchiveModel };
+export { WebModel, UserModel };

--- a/src/modules/sqlModel.ts
+++ b/src/modules/sqlModel.ts
@@ -11,8 +11,8 @@ import {
 	InferAttributes,
 	InferCreationAttributes,
 	Model,
+	Op,
 } from "sequelize";
-import { Op } from "sequelize";
 
 import { config } from "../config";
 import { WaitToRunMessageQueue } from "../utils/messageQueue";

--- a/src/utils/archiveManager.ts
+++ b/src/utils/archiveManager.ts
@@ -1,495 +1,270 @@
-// 归档管理模块
-// By [AmisKwok](https://github.com/AmisKwok)
-import axios, { AxiosError } from "axios";
+//  ____            _               __  __                          _          _    ____    _   _  ___
+// | __ )  __ _ ___| |__           |  \/  | __ _ _ __   __ _  __ _| |_ ___   / \  | |_|__ \  / |/ ___|
+// |  _ \ / _` / __| '_ \   _____  | |\/| |/ _` | '_ \ / _` |/ _` | __/ _ \ / _ \ | __| / /  | | |  _
+// | |_) | (_| \__ \ | | | |_____| | |  | | (_| | | | | (_| | (_| | ||  __// ___ \| |_ / /_  | | |_| |
+// |____/ \__,_|___/_| |_|         |_|  |_|\__,_|_| |_|\__, |\__,_|\__\___/_/   \_\__|____| |_|\____|
+//
+// 站点回收站 / 归档 / 软删除 管理工具
+// 重构自双表硬删除方案：改为在 webs 表内用 status 标记 ARCHIVED / DELETED 实现软删除。
 import { Op } from "sequelize";
 
 import { botManager } from "../bot/botManager";
 import { config } from "../config";
-import sql from "../modules/sqlConfig";
-import { ArchiveModel, WebModel } from "../modules/sqlModel";
+import {
+	ARCHIVE_STATUS,
+	DELETED_STATUS,
+	WebModel,
+	WebStatus,
+} from "../modules/sqlModel";
 import { Logger } from "../modules/typedLogger";
 
-// axios 检查配置
-const axiosConfig = {
-	headers: {
-		"User-Agent":
-			"Mozilla/5.0 (compatible; Travellings Check Bot; +https://www.travellings.cn/docs/qa)",
-	},
-	timeout: config.LOAD_TIMEOUT * 1000,
-	maxRedirects: 5,
-	validateStatus: null,
-};
-
-const logger = new Logger("ArchiveManager");
+const archiveLogger = new Logger("_Archive");
 
 /**
- * 快速检查单个 URL（简化版，只检查 HTTP 状态，不检查内容）
+ * 将站点归档（进入回收站）。
+ *
+ * 仅把该站点的 status 改为 `ARCHIVED`，原记录保留在 webs 表，
+ * 不再写入独立的 archives 表（避免数据冗余与不一致）。
+ *
+ * @param site 要归档的 WebModel 实例（任意非 RUN/DELETED 状态均可）
+ * @param reason 归档原因，记录在 lastUpdated 备注（可选，写入 failedReason 仅作留痕不建议覆盖）
  */
-async function quickCheckURL(
-	siteURL: string,
-): Promise<{ status: string; isOk: boolean }> {
+export async function archiveSite(
+	site: WebModel,
+	reason?: string,
+): Promise<void> {
 	try {
-		const response = await axios.get(siteURL, axiosConfig);
-		if ([200, 304].includes(response.status)) {
-			return { status: "RUN", isOk: true };
+		if (site.status === ARCHIVE_STATUS || site.status === DELETED_STATUS) {
+			archiveLogger.debug(
+				`ID >> ${site.id}, 已是归档/删除状态，跳过`,
+				"ARCHIVE",
+			);
+			return;
 		}
-		if (response.status.toString().startsWith("4")) {
-			return { status: response.status.toString(), isOk: false };
+		site.status = ARCHIVE_STATUS;
+		// 记录归档时间到 lastUpdated，方便回收站展示「停留时长」
+		site.lastUpdated = new Date();
+		if (reason) {
+			site.failedReason = reason;
 		}
-		if (response.status.toString().startsWith("5")) {
-			return { status: response.status.toString(), isOk: false };
-		}
-		return { status: "ERROR", isOk: false };
+		await site.save();
+		archiveLogger.info(
+			`ID >> ${site.id}, 已归档（status → ${ARCHIVE_STATUS}）`,
+			"ARCHIVE",
+		);
 	} catch (error) {
-		if (error instanceof AxiosError) {
-			if (error.code === "ECONNABORTED") {
-				return { status: "TIMEOUT", isOk: false };
-			}
-		}
-		return { status: "ERROR", isOk: false };
+		archiveLogger.err(
+			`ID >> ${site.id}, 归档失败：${(error as Error).message}`,
+			"ARCHIVE",
+		);
+		throw error;
 	}
 }
 
 /**
- * 根据状态获取归档原因描述
- */
-function getArchiveReason(status: string): string {
-	const reasonMap: Record<string, string> = {
-		LOST: "站点失去联系",
-		ERROR: "站点访问错误",
-		TIMEOUT: "站点访问超时",
-	};
-	if (status.startsWith("4")) {
-		return `客户端错误 ${status}`;
-	}
-	if (status.startsWith("5")) {
-		return `服务器错误 ${status}`;
-	}
-	return reasonMap[status] || `状态异常: ${status}`;
-}
-
-/**
- * 执行自动归档巡查
- */
-export async function runAutoArchive(): Promise<{
-	archivedCount: number;
-	archivedSites: Array<{
-		id: number;
-		name: string;
-		link: string;
-		reason: string;
-	}>;
-	recoveredCount: number;
-}> {
-	logger.info("开始执行自动归档巡查", "Archive");
-
-	// 发送开始通知
-	botManager.boardcastRichTextMessage([
-		[{ type: "text", bold: true, content: "🚀 回收站自动巡查开始" }],
-		[{ type: "text", content: "" }],
-		[
-			{
-				type: "text",
-				content: `正在扫描符合归档条件的站点 (阈值: ${config.AUTO_ARCHIVE_THRESHOLD_DAYS} 天)`,
-			},
-		],
-		config.ARCHIVE_RECHECK_BEFORE
-			? [
-					{
-						type: "text",
-						content: "🔍 归档前将重新检查站点状态 (使用 axios)",
-					},
-				]
-			: [],
-	]);
-
-	const thresholdDate = new Date(
-		Date.now() - config.AUTO_ARCHIVE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000,
-	);
-
-	// 查找符合条件的站点 (状态异常)
-	const sitesToCheck = await WebModel.findAll({
-		where: {
-			[Op.and]: [
-				{
-					[Op.or]: [
-						{ status: { [Op.in]: ["LOST", "ERROR", "TIMEOUT"] } },
-						{ status: { [Op.like]: "4%" } },
-						{ status: { [Op.like]: "5%" } },
-					],
-				},
-				{
-					[Op.or]: [
-						{ lastUpdated: { [Op.lt]: thresholdDate } },
-						{ lastUpdated: { [Op.is]: null } },
-					],
-				},
-			],
-		},
-	});
-
-	if (sitesToCheck.length === 0) {
-		logger.info("没有需要归档的站点", "Archive");
-		botManager.boardcastRichTextMessage([
-			[{ type: "text", bold: true, content: "✅ 回收站巡查完成" }],
-			[{ type: "text", content: "" }],
-			[{ type: "text", content: "没有发现需要归档的站点" }],
-		]);
-		return { archivedCount: 0, archivedSites: [], recoveredCount: 0 };
-	}
-
-	const archivedSites: Array<{
-		id: number;
-		name: string;
-		link: string;
-		reason: string;
-	}> = [];
-	const recoveredSites: Array<{
-		id: number;
-		name: string;
-		link: string;
-	}> = [];
-
-	// 使用事务进行处理
-	await sql.transaction(async (t) => {
-		for (const site of sitesToCheck) {
-			if (!site) continue;
-
-			let currentStatus = site.status || "";
-
-			// 如果启用了检查，在归档前重新检查
-			if (config.ARCHIVE_RECHECK_BEFORE) {
-				try {
-					const checkResult = await quickCheckURL(site.link);
-					if (checkResult.isOk) {
-						// 站点已经恢复了，更新它而不归档
-						await site.update(
-							{
-								status: "RUN",
-								failedReason: null,
-								lastUpdated: new Date(),
-							},
-							{ transaction: t },
-						);
-						recoveredSites.push({
-							id: site.id,
-							name: site.name,
-							link: site.link,
-						});
-						logger.info(
-							`站点已恢复，不归档: ${site.name} (${site.link})`,
-							"Archive",
-						);
-						continue;
-					}
-					// 状态没恢复，还是用新状态
-					currentStatus = checkResult.status;
-				} catch {
-					// 检查出错，还是用原状态继续
-					logger.warn(
-						`检查站点失败: ${site.name} - 使用原状态继续`,
-						"Archive",
-					);
-				}
-			}
-
-			// 执行归档
-			const reason = getArchiveReason(currentStatus);
-
-			await ArchiveModel.create(
-				{
-					originalId: site.id,
-					status: site.status,
-					name: site.name,
-					link: site.link,
-					tag: site.tag,
-					failedReason: site.failedReason,
-					lastManualCheck: site.lastManualCheck,
-					lastUpdated: site.lastUpdated,
-					archivedAt: new Date(),
-					archiveReason: reason,
-				},
-				{ transaction: t },
-			);
-
-			await site.destroy({ transaction: t });
-
-			archivedSites.push({
-				id: site.id,
-				name: site.name,
-				link: site.link,
-				reason: reason,
-			});
-
-			logger.info(
-				`已归档站点: ${site.name} (${site.link}) - 原因: ${reason}`,
-				"Archive",
-			);
-		}
-	});
-
-	// 发送完成通知
-	const messageParts = [
-		[
-			{
-				type: "text",
-				bold: true,
-				content: config.ARCHIVE_RECHECK_BEFORE
-					? "✅ 回收站巡查完成 [已重新检查]"
-					: "✅ 回收站巡查完成 [未重新检查]",
-			},
-		],
-		[{ type: "text", content: "" }],
-	];
-
-	// 添加恢复的站点信息
-	if (recoveredSites.length > 0) {
-		messageParts.push([
-			{
-				type: "text",
-				bold: true,
-				content: `🎉 发现 ${recoveredSites.length} 个站点已恢复:`,
-			},
-		]);
-		const showRecoveredCount = Math.min(recoveredSites.length, 10);
-		for (let i = 0; i < showRecoveredCount; i++) {
-			const site = recoveredSites[i];
-			if (site) {
-				messageParts.push([
-					{
-						type: "text",
-						content: `• ${site.name} - 已恢复正常`,
-					},
-				]);
-			}
-		}
-		if (recoveredSites.length > 10) {
-			messageParts.push([
-				{
-					type: "text",
-					content: `... 还有 ${recoveredSites.length - 10} 个站点`,
-				},
-			]);
-		}
-		messageParts.push([{ type: "text", content: "" }]);
-	}
-
-	// 添加归档的站点信息
-	if (archivedSites.length > 0) {
-		messageParts.push([
-			{
-				type: "text",
-				bold: true,
-				content: `📦 共归档 ${archivedSites.length} 个站点:`,
-			},
-		]);
-		const showArchivedCount = Math.min(archivedSites.length, 10);
-		for (let i = 0; i < showArchivedCount; i++) {
-			const site = archivedSites[i];
-			if (site) {
-				messageParts.push([
-					{
-						type: "text",
-						content: `• ${site.name} - ${site.reason}`,
-					},
-				]);
-			}
-		}
-		if (archivedSites.length > 10) {
-			messageParts.push([
-				{
-					type: "text",
-					content: `... 还有 ${archivedSites.length - 10} 个站点`,
-				},
-			]);
-		}
-	} else {
-		messageParts.push([
-			{ type: "text", content: "没有发现需要归档的站点" },
-		]);
-	}
-
-	messageParts.push([{ type: "text", content: "" }]);
-	messageParts.push([{ type: "text", content: "使用 /archives 查看回收站" }]);
-
-	botManager.boardcastRichTextMessage(messageParts);
-
-	return {
-		archivedCount: archivedSites.length,
-		archivedSites,
-		recoveredCount: recoveredSites.length,
-	};
-}
-
-/**
- * 获取回收站列表
- */
-export async function getArchives(
-	limit: number = 50,
-	offset: number = 0,
-): Promise<ArchiveModel[]> {
-	return await ArchiveModel.findAll({
-		order: [["archivedAt", "DESC"]],
-		limit,
-		offset,
-	});
-}
-
-/**
- * 恢复单个站点
+ * 从回收站恢复站点。
+ *
+ * 将 status 从 ARCHIVED 改回 RUN（恢复即重新参与跳转与巡查）。
+ * 如需恢复为其他状态，可传入 targetStatus。
  */
 export async function restoreArchive(
-	archiveId: number,
-): Promise<WebModel | null> {
-	const archive = await ArchiveModel.findByPk(archiveId);
-	if (!archive) {
-		logger.warn(`未找到归档记录 ID: ${archiveId}`, "Restore");
-		return null;
-	}
-
-	let restoredSite: WebModel | null = null;
-
-	await sql.transaction(async (t) => {
-		// 恢复到 webs 表
-		restoredSite = await WebModel.create(
-			{
-				id: archive.originalId,
-				status: archive.status,
-				name: archive.name,
-				link: archive.link,
-				tag: archive.tag,
-				failedReason: archive.failedReason,
-				lastManualCheck: archive.lastManualCheck,
-				lastUpdated: archive.lastUpdated,
+	id: number,
+	targetStatus: string = WebStatus.RUN,
+): Promise<boolean> {
+	try {
+		// 回收站查询需要绕过 defaultScope（defaultScope 隐藏 DELETED，这里查 ARCHIVED 用 unscoped）
+		const site = await WebModel.unscoped().findOne({
+			where: {
+				id,
+				status: ARCHIVE_STATUS,
 			},
-			{ transaction: t },
+		});
+		if (!site) {
+			archiveLogger.err(`ID >> ${id}, 回收站中未找到该站点`, "ARCHIVE");
+			return false;
+		}
+		site.status = targetStatus;
+		site.lastUpdated = new Date();
+		await site.save();
+		archiveLogger.info(
+			`ID >> ${id}, 已恢复（status → ${targetStatus}）`,
+			"ARCHIVE",
 		);
-
-		// 删除归档记录
-		await archive.destroy({ transaction: t });
-	});
-
-	logger.info(`已恢复站点: ${archive.name} (${archive.link})`, "Restore");
-
-	botManager.boardcastRichTextMessage([
-		[{ type: "text", bold: true, content: "♻️ 站点已恢复" }],
-		[{ type: "text", content: "" }],
-		[{ type: "text", content: `名称: ${archive.name}` }],
-		[{ type: "text", content: `链接: ${archive.link}` }],
-	]);
-
-	return restoredSite;
-}
-
-/**
- * 永久删除单个归档记录
- */
-export async function deleteArchive(archiveId: number): Promise<boolean> {
-	const archive = await ArchiveModel.findByPk(archiveId);
-	if (!archive) {
-		logger.warn(`未找到归档记录 ID: ${archiveId}`, "Delete");
+		return true;
+	} catch (error) {
+		archiveLogger.err(
+			`ID >> ${id}, 恢复失败：${(error as Error).message}`,
+			"ARCHIVE",
+		);
 		return false;
 	}
-
-	await archive.destroy();
-
-	logger.info(`已永久删除归档: ${archive.name} (${archive.link})`, "Delete");
-
-	botManager.boardcastRichTextMessage([
-		[{ type: "text", bold: true, content: "🗑️ 归档已删除" }],
-		[{ type: "text", content: "" }],
-		[{ type: "text", content: `名称: ${archive.name}` }],
-		[{ type: "text", content: `链接: ${archive.link}` }],
-	]);
-
-	return true;
 }
 
 /**
- * 清空回收站
+ * 永久删除（软删除）。
+ *
+ * 仅把 status 改为 DELETED，原记录保留。defaultScope 已保证
+ * 对外查询（巡查 / query 命令 / 对外 API）默认看不到 DELETED 站点，
+ * 即实现「软删除 / API 隐藏」效果，无需真正 DELETE 行。
+ *
+ * @param id 站点 ID
+ * @returns 是否成功
+ */
+export async function deleteArchive(id: number): Promise<boolean> {
+	try {
+		const site = await WebModel.unscoped().findOne({
+			where: {
+				id,
+				status: ARCHIVE_STATUS,
+			},
+		});
+		if (!site) {
+			archiveLogger.err(`ID >> ${id}, 回收站中未找到该站点`, "ARCHIVE");
+			return false;
+		}
+		site.status = DELETED_STATUS;
+		site.lastUpdated = new Date();
+		await site.save();
+		archiveLogger.info(
+			`ID >> ${id}, 已软删除（status → ${DELETED_STATUS}）`,
+			"ARCHIVE",
+		);
+		return true;
+	} catch (error) {
+		archiveLogger.err(
+			`ID >> ${id}, 软删除失败：${(error as Error).message}`,
+			"ARCHIVE",
+		);
+		return false;
+	}
+}
+
+/**
+ * 获取回收站中的所有站点（status = ARCHIVED）。
+ */
+export async function getArchives(): Promise<WebModel[]> {
+	try {
+		return await WebModel.unscoped().findAll({
+			where: {
+				status: ARCHIVE_STATUS,
+			},
+			order: [["lastUpdated", "DESC"]],
+		});
+	} catch (error) {
+		archiveLogger.err(
+			`获取回收站失败：${(error as Error).message}`,
+			"ARCHIVE",
+		);
+		return [];
+	}
+}
+
+/**
+ * 清空整个回收站（全部软删除）。
+ *
+ * 注意：这是对回收站内所有 ARCHIVED 站点执行软删除（status → DELETED），
+ * 不会真正删除数据库行，保证数据安全可回溯。
  */
 export async function clearAllArchives(): Promise<number> {
-	const count = await ArchiveModel.count();
-	if (count === 0) {
+	try {
+		const [affectedCount] = await WebModel.unscoped().update(
+			{
+				status: DELETED_STATUS,
+				lastUpdated: new Date(),
+			},
+			{
+				where: {
+					status: ARCHIVE_STATUS,
+				},
+			},
+		);
+		archiveLogger.info(
+			`已清空回收站，软删除 ${affectedCount} 个站点`,
+			"ARCHIVE",
+		);
+		return affectedCount;
+	} catch (error) {
+		archiveLogger.err(
+			`清空回收站失败：${(error as Error).message}`,
+			"ARCHIVE",
+		);
 		return 0;
 	}
-
-	await ArchiveModel.destroy({ where: {} });
-
-	logger.info(`已清空回收站，共删除 ${count} 个归档`, "ClearAll");
-
-	botManager.boardcastRichTextMessage([
-		[{ type: "text", bold: true, content: "🧹 回收站已清空" }],
-		[{ type: "text", content: "" }],
-		[
-			{
-				type: "text",
-				content: `共永久删除 ${count} 个归档记录`,
-			},
-		],
-	]);
-
-	return count;
 }
 
 /**
- * 获取所有归档状态列表
+ * 自动归档巡查发现的异常站点。
+ *
+ * 根据配置的时间阈值，将长期停留在 LOST / ERROR / 4xx / TIMEOUT 等
+ * 异常状态的站点自动标记到回收站（status → ARCHIVED）。
+ * 不再依赖独立 archives 表。
  */
-export async function getArchiveStatuses(): Promise<
-	Array<{ status: string; count: number }>
-> {
-	const archives = await ArchiveModel.findAll({
-		attributes: ["status"],
-	});
+export async function runAutoArchive(): Promise<void> {
+	try {
+		const autoArchiveEnabled = config.AUTO_ARCHIVE_ENABLE;
+		if (!autoArchiveEnabled) {
+			archiveLogger.debug("自动归档未启用，跳过", "ARCHIVE");
+			return;
+		}
 
-	const statusCount: Record<string, number> = {};
-	archives.forEach((archive) => {
-		const status = archive.status || "未知";
-		statusCount[status] = (statusCount[status] || 0) + 1;
-	});
+		const autoArchiveDays = config.AUTO_ARCHIVE_THRESHOLD_DAYS || 365;
+		const thresholdDate = new Date(
+			Date.now() - autoArchiveDays * 24 * 60 * 60 * 1000,
+		);
+		archiveLogger.info(
+			`开始自动归档（异常停留超过 ${autoArchiveDays} 天）`,
+			"ARCHIVE",
+		);
 
-	return Object.entries(statusCount)
-		.map(([status, count]) => ({ status, count }))
-		.sort((a, b) => b.count - a.count);
-}
+		// 需要自动归档的异常状态（不含 WAIT：WAIT 需人工审核，不强转 ARCHIVED）
+		const autoArchiveStatuses = [
+			WebStatus.LOST,
+			WebStatus.ERROR,
+			WebStatus.TIMEOUT,
+			"403",
+			"404",
+			"500",
+		];
 
-/**
- * 按状态删除归档
- */
-export async function deleteArchivesByStatus(status: string): Promise<number> {
-	const archives = await ArchiveModel.findAll({
-		where: { status: status },
-	});
+		const candidates = await WebModel.findAll({
+			where: {
+				status: {
+					[Op.in]: autoArchiveStatuses,
+				},
+				lastManualCheck: {
+					[Op.or]: [{ [Op.eq]: null }, { [Op.lt]: thresholdDate }],
+				},
+			},
+		});
 
-	if (archives.length === 0) {
-		return 0;
+		let archivedCount = 0;
+		for (const site of candidates) {
+			try {
+				await archiveSite(
+					site,
+					`自动归档：异常状态 ${site.status} 停留超过 ${autoArchiveDays} 天`,
+				);
+				archivedCount++;
+			} catch {
+				// 单个失败不影响整体
+			}
+		}
+
+		archiveLogger.info(
+			`自动归档完成，共 ${archivedCount} 个站点`,
+			"ARCHIVE",
+		);
+
+		// 通知管理员
+		if (archivedCount > 0 && !config.NO_TOKEN_MODE) {
+			await botManager.boardcastMessage(
+				`🔧 自动归档完成：共 ${archivedCount} 个异常站点被移入回收站。`,
+			);
+		}
+	} catch (error) {
+		archiveLogger.err(
+			`自动归档失败：${(error as Error).message}`,
+			"ARCHIVE",
+		);
 	}
-
-	await ArchiveModel.destroy({
-		where: { status: status },
-	});
-
-	logger.info(
-		`已按状态删除 ${archives.length} 个归档: ${status}`,
-		"DeleteByStatus",
-	);
-
-	botManager.boardcastRichTextMessage([
-		[{ type: "text", bold: true, content: "🗂️ 批量删除完成" }],
-		[{ type: "text", content: "" }],
-		[
-			{
-				type: "text",
-				content: `状态: ${status}`,
-			},
-		],
-		[
-			{
-				type: "text",
-				content: `共删除 ${archives.length} 个归档记录`,
-			},
-		],
-	]);
-
-	return archives.length;
 }

--- a/src/utils/archiveManager.ts
+++ b/src/utils/archiveManager.ts
@@ -1,0 +1,495 @@
+// 归档管理模块
+// By [AmisKwok](https://github.com/AmisKwok)
+import axios, { AxiosError } from "axios";
+import { Op } from "sequelize";
+
+import { botManager } from "../bot/botManager";
+import { config } from "../config";
+import sql from "../modules/sqlConfig";
+import { ArchiveModel, WebModel } from "../modules/sqlModel";
+import { Logger } from "../modules/typedLogger";
+
+// axios 检查配置
+const axiosConfig = {
+	headers: {
+		"User-Agent":
+			"Mozilla/5.0 (compatible; Travellings Check Bot; +https://www.travellings.cn/docs/qa)",
+	},
+	timeout: config.LOAD_TIMEOUT * 1000,
+	maxRedirects: 5,
+	validateStatus: null,
+};
+
+const logger = new Logger("ArchiveManager");
+
+/**
+ * 快速检查单个 URL（简化版，只检查 HTTP 状态，不检查内容）
+ */
+async function quickCheckURL(
+	siteURL: string,
+): Promise<{ status: string; isOk: boolean }> {
+	try {
+		const response = await axios.get(siteURL, axiosConfig);
+		if ([200, 304].includes(response.status)) {
+			return { status: "RUN", isOk: true };
+		}
+		if (response.status.toString().startsWith("4")) {
+			return { status: response.status.toString(), isOk: false };
+		}
+		if (response.status.toString().startsWith("5")) {
+			return { status: response.status.toString(), isOk: false };
+		}
+		return { status: "ERROR", isOk: false };
+	} catch (error) {
+		if (error instanceof AxiosError) {
+			if (error.code === "ECONNABORTED") {
+				return { status: "TIMEOUT", isOk: false };
+			}
+		}
+		return { status: "ERROR", isOk: false };
+	}
+}
+
+/**
+ * 根据状态获取归档原因描述
+ */
+function getArchiveReason(status: string): string {
+	const reasonMap: Record<string, string> = {
+		LOST: "站点失去联系",
+		ERROR: "站点访问错误",
+		TIMEOUT: "站点访问超时",
+	};
+	if (status.startsWith("4")) {
+		return `客户端错误 ${status}`;
+	}
+	if (status.startsWith("5")) {
+		return `服务器错误 ${status}`;
+	}
+	return reasonMap[status] || `状态异常: ${status}`;
+}
+
+/**
+ * 执行自动归档巡查
+ */
+export async function runAutoArchive(): Promise<{
+	archivedCount: number;
+	archivedSites: Array<{
+		id: number;
+		name: string;
+		link: string;
+		reason: string;
+	}>;
+	recoveredCount: number;
+}> {
+	logger.info("开始执行自动归档巡查", "Archive");
+
+	// 发送开始通知
+	botManager.boardcastRichTextMessage([
+		[{ type: "text", bold: true, content: "🚀 回收站自动巡查开始" }],
+		[{ type: "text", content: "" }],
+		[
+			{
+				type: "text",
+				content: `正在扫描符合归档条件的站点 (阈值: ${config.AUTO_ARCHIVE_THRESHOLD_DAYS} 天)`,
+			},
+		],
+		config.ARCHIVE_RECHECK_BEFORE
+			? [
+					{
+						type: "text",
+						content: "🔍 归档前将重新检查站点状态 (使用 axios)",
+					},
+				]
+			: [],
+	]);
+
+	const thresholdDate = new Date(
+		Date.now() - config.AUTO_ARCHIVE_THRESHOLD_DAYS * 24 * 60 * 60 * 1000,
+	);
+
+	// 查找符合条件的站点 (状态异常)
+	const sitesToCheck = await WebModel.findAll({
+		where: {
+			[Op.and]: [
+				{
+					[Op.or]: [
+						{ status: { [Op.in]: ["LOST", "ERROR", "TIMEOUT"] } },
+						{ status: { [Op.like]: "4%" } },
+						{ status: { [Op.like]: "5%" } },
+					],
+				},
+				{
+					[Op.or]: [
+						{ lastUpdated: { [Op.lt]: thresholdDate } },
+						{ lastUpdated: { [Op.is]: null } },
+					],
+				},
+			],
+		},
+	});
+
+	if (sitesToCheck.length === 0) {
+		logger.info("没有需要归档的站点", "Archive");
+		botManager.boardcastRichTextMessage([
+			[{ type: "text", bold: true, content: "✅ 回收站巡查完成" }],
+			[{ type: "text", content: "" }],
+			[{ type: "text", content: "没有发现需要归档的站点" }],
+		]);
+		return { archivedCount: 0, archivedSites: [], recoveredCount: 0 };
+	}
+
+	const archivedSites: Array<{
+		id: number;
+		name: string;
+		link: string;
+		reason: string;
+	}> = [];
+	const recoveredSites: Array<{
+		id: number;
+		name: string;
+		link: string;
+	}> = [];
+
+	// 使用事务进行处理
+	await sql.transaction(async (t) => {
+		for (const site of sitesToCheck) {
+			if (!site) continue;
+
+			let currentStatus = site.status || "";
+
+			// 如果启用了检查，在归档前重新检查
+			if (config.ARCHIVE_RECHECK_BEFORE) {
+				try {
+					const checkResult = await quickCheckURL(site.link);
+					if (checkResult.isOk) {
+						// 站点已经恢复了，更新它而不归档
+						await site.update(
+							{
+								status: "RUN",
+								failedReason: null,
+								lastUpdated: new Date(),
+							},
+							{ transaction: t },
+						);
+						recoveredSites.push({
+							id: site.id,
+							name: site.name,
+							link: site.link,
+						});
+						logger.info(
+							`站点已恢复，不归档: ${site.name} (${site.link})`,
+							"Archive",
+						);
+						continue;
+					}
+					// 状态没恢复，还是用新状态
+					currentStatus = checkResult.status;
+				} catch {
+					// 检查出错，还是用原状态继续
+					logger.warn(
+						`检查站点失败: ${site.name} - 使用原状态继续`,
+						"Archive",
+					);
+				}
+			}
+
+			// 执行归档
+			const reason = getArchiveReason(currentStatus);
+
+			await ArchiveModel.create(
+				{
+					originalId: site.id,
+					status: site.status,
+					name: site.name,
+					link: site.link,
+					tag: site.tag,
+					failedReason: site.failedReason,
+					lastManualCheck: site.lastManualCheck,
+					lastUpdated: site.lastUpdated,
+					archivedAt: new Date(),
+					archiveReason: reason,
+				},
+				{ transaction: t },
+			);
+
+			await site.destroy({ transaction: t });
+
+			archivedSites.push({
+				id: site.id,
+				name: site.name,
+				link: site.link,
+				reason: reason,
+			});
+
+			logger.info(
+				`已归档站点: ${site.name} (${site.link}) - 原因: ${reason}`,
+				"Archive",
+			);
+		}
+	});
+
+	// 发送完成通知
+	const messageParts = [
+		[
+			{
+				type: "text",
+				bold: true,
+				content: config.ARCHIVE_RECHECK_BEFORE
+					? "✅ 回收站巡查完成 [已重新检查]"
+					: "✅ 回收站巡查完成 [未重新检查]",
+			},
+		],
+		[{ type: "text", content: "" }],
+	];
+
+	// 添加恢复的站点信息
+	if (recoveredSites.length > 0) {
+		messageParts.push([
+			{
+				type: "text",
+				bold: true,
+				content: `🎉 发现 ${recoveredSites.length} 个站点已恢复:`,
+			},
+		]);
+		const showRecoveredCount = Math.min(recoveredSites.length, 10);
+		for (let i = 0; i < showRecoveredCount; i++) {
+			const site = recoveredSites[i];
+			if (site) {
+				messageParts.push([
+					{
+						type: "text",
+						content: `• ${site.name} - 已恢复正常`,
+					},
+				]);
+			}
+		}
+		if (recoveredSites.length > 10) {
+			messageParts.push([
+				{
+					type: "text",
+					content: `... 还有 ${recoveredSites.length - 10} 个站点`,
+				},
+			]);
+		}
+		messageParts.push([{ type: "text", content: "" }]);
+	}
+
+	// 添加归档的站点信息
+	if (archivedSites.length > 0) {
+		messageParts.push([
+			{
+				type: "text",
+				bold: true,
+				content: `📦 共归档 ${archivedSites.length} 个站点:`,
+			},
+		]);
+		const showArchivedCount = Math.min(archivedSites.length, 10);
+		for (let i = 0; i < showArchivedCount; i++) {
+			const site = archivedSites[i];
+			if (site) {
+				messageParts.push([
+					{
+						type: "text",
+						content: `• ${site.name} - ${site.reason}`,
+					},
+				]);
+			}
+		}
+		if (archivedSites.length > 10) {
+			messageParts.push([
+				{
+					type: "text",
+					content: `... 还有 ${archivedSites.length - 10} 个站点`,
+				},
+			]);
+		}
+	} else {
+		messageParts.push([
+			{ type: "text", content: "没有发现需要归档的站点" },
+		]);
+	}
+
+	messageParts.push([{ type: "text", content: "" }]);
+	messageParts.push([{ type: "text", content: "使用 /archives 查看回收站" }]);
+
+	botManager.boardcastRichTextMessage(messageParts);
+
+	return {
+		archivedCount: archivedSites.length,
+		archivedSites,
+		recoveredCount: recoveredSites.length,
+	};
+}
+
+/**
+ * 获取回收站列表
+ */
+export async function getArchives(
+	limit: number = 50,
+	offset: number = 0,
+): Promise<ArchiveModel[]> {
+	return await ArchiveModel.findAll({
+		order: [["archivedAt", "DESC"]],
+		limit,
+		offset,
+	});
+}
+
+/**
+ * 恢复单个站点
+ */
+export async function restoreArchive(
+	archiveId: number,
+): Promise<WebModel | null> {
+	const archive = await ArchiveModel.findByPk(archiveId);
+	if (!archive) {
+		logger.warn(`未找到归档记录 ID: ${archiveId}`, "Restore");
+		return null;
+	}
+
+	let restoredSite: WebModel | null = null;
+
+	await sql.transaction(async (t) => {
+		// 恢复到 webs 表
+		restoredSite = await WebModel.create(
+			{
+				id: archive.originalId,
+				status: archive.status,
+				name: archive.name,
+				link: archive.link,
+				tag: archive.tag,
+				failedReason: archive.failedReason,
+				lastManualCheck: archive.lastManualCheck,
+				lastUpdated: archive.lastUpdated,
+			},
+			{ transaction: t },
+		);
+
+		// 删除归档记录
+		await archive.destroy({ transaction: t });
+	});
+
+	logger.info(`已恢复站点: ${archive.name} (${archive.link})`, "Restore");
+
+	botManager.boardcastRichTextMessage([
+		[{ type: "text", bold: true, content: "♻️ 站点已恢复" }],
+		[{ type: "text", content: "" }],
+		[{ type: "text", content: `名称: ${archive.name}` }],
+		[{ type: "text", content: `链接: ${archive.link}` }],
+	]);
+
+	return restoredSite;
+}
+
+/**
+ * 永久删除单个归档记录
+ */
+export async function deleteArchive(archiveId: number): Promise<boolean> {
+	const archive = await ArchiveModel.findByPk(archiveId);
+	if (!archive) {
+		logger.warn(`未找到归档记录 ID: ${archiveId}`, "Delete");
+		return false;
+	}
+
+	await archive.destroy();
+
+	logger.info(`已永久删除归档: ${archive.name} (${archive.link})`, "Delete");
+
+	botManager.boardcastRichTextMessage([
+		[{ type: "text", bold: true, content: "🗑️ 归档已删除" }],
+		[{ type: "text", content: "" }],
+		[{ type: "text", content: `名称: ${archive.name}` }],
+		[{ type: "text", content: `链接: ${archive.link}` }],
+	]);
+
+	return true;
+}
+
+/**
+ * 清空回收站
+ */
+export async function clearAllArchives(): Promise<number> {
+	const count = await ArchiveModel.count();
+	if (count === 0) {
+		return 0;
+	}
+
+	await ArchiveModel.destroy({ where: {} });
+
+	logger.info(`已清空回收站，共删除 ${count} 个归档`, "ClearAll");
+
+	botManager.boardcastRichTextMessage([
+		[{ type: "text", bold: true, content: "🧹 回收站已清空" }],
+		[{ type: "text", content: "" }],
+		[
+			{
+				type: "text",
+				content: `共永久删除 ${count} 个归档记录`,
+			},
+		],
+	]);
+
+	return count;
+}
+
+/**
+ * 获取所有归档状态列表
+ */
+export async function getArchiveStatuses(): Promise<
+	Array<{ status: string; count: number }>
+> {
+	const archives = await ArchiveModel.findAll({
+		attributes: ["status"],
+	});
+
+	const statusCount: Record<string, number> = {};
+	archives.forEach((archive) => {
+		const status = archive.status || "未知";
+		statusCount[status] = (statusCount[status] || 0) + 1;
+	});
+
+	return Object.entries(statusCount)
+		.map(([status, count]) => ({ status, count }))
+		.sort((a, b) => b.count - a.count);
+}
+
+/**
+ * 按状态删除归档
+ */
+export async function deleteArchivesByStatus(status: string): Promise<number> {
+	const archives = await ArchiveModel.findAll({
+		where: { status: status },
+	});
+
+	if (archives.length === 0) {
+		return 0;
+	}
+
+	await ArchiveModel.destroy({
+		where: { status: status },
+	});
+
+	logger.info(
+		`已按状态删除 ${archives.length} 个归档: ${status}`,
+		"DeleteByStatus",
+	);
+
+	botManager.boardcastRichTextMessage([
+		[{ type: "text", bold: true, content: "🗂️ 批量删除完成" }],
+		[{ type: "text", content: "" }],
+		[
+			{
+				type: "text",
+				content: `状态: ${status}`,
+			},
+		],
+		[
+			{
+				type: "text",
+				content: `共删除 ${archives.length} 个归档记录`,
+			},
+		],
+	]);
+
+	return archives.length;
+}


### PR DESCRIPTION
## 背景
当前 `.github/workflows/nodejs_ci.yml` 只跑了 `pnpm build`，缺少代码质量检查和依赖锁定，
导致一些本可在 CI 拦截的问题（如之前 PR 上的 `sequelize imported multiple times` 重复导入警告）漏到人工 review 阶段。

## 改动
- 新增 **Lint 步骤**（`pnpm lint` = tsc --noEmit + eslint），提前拦截代码风格/导入问题
- `pnpm install` 增加 `--frozen-lockfile`，锁定依赖版本，保证 CI 与 lockfile 一致
- 添加 `concurrency` 配置，同一分支重复触发时自动取消冗余运行，节省资源
- 添加 `timeout-minutes: 15`，防止某步骤卡死长期占用 runner
- 移除硬编码的 `pnpm version: 9`，改用 `pnpm/action-setup@v4` 自动读取 `package.json` 中的 `packageManager` 字段（当前 pnpm@10.7.1），避免与本地版本不一致

## 影响
- 仅修改 CI 工作流文件，不涉及业务代码
- 更严格的质量门禁：后续 PR 若未通过 lint 将直接失败

## 测试
本地已通过 `pnpm lint`（0 error，仅 1 个既有 warning）与 `pnpm build`
